### PR TITLE
fix: Export type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/ip.mjs",
-			"require": "./dist/ip.cjs"
+			"require": "./dist/ip.cjs",
+            "types": "./dist/ip.d.ts"
 		}
 	},
 	"devDependencies": {


### PR DESCRIPTION
Lack of this line causes an error during `tsc`
```
Could not find a declaration file for module 'neoip'
```
When `neoip` package is installed in Typescript project